### PR TITLE
fix constraints for sliderView and transpo buttons

### DIFF
--- a/quavi/quavi/Controllers/MapView/MapViewController+Constraints.swift
+++ b/quavi/quavi/Controllers/MapView/MapViewController+Constraints.swift
@@ -37,7 +37,7 @@ extension MapViewController {
         NSLayoutConstraint.activate([
             mapView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
             mapView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
-            mapView.topAnchor.constraint(equalTo: view.topAnchor)
+            //mapView.topAnchor.constraint(equalTo: view.topAnchor)
         ])
         
         
@@ -59,7 +59,7 @@ extension MapViewController {
     //MARK: -bike button constraints
     func setBikeButtonConstraints(){
         bikeButton.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([bikeButton.topAnchor.constraint(equalTo: mapView.topAnchor, constant: 35), bikeButton.centerXAnchor.constraint(equalTo: mapView.centerXAnchor), bikeButton.heightAnchor.constraint(equalToConstant: 50), bikeButton.widthAnchor.constraint(equalToConstant: 50)])
+        NSLayoutConstraint.activate([bikeButton.topAnchor.constraint(equalTo: mapView.safeAreaLayoutGuide.topAnchor, constant: 35), bikeButton.centerXAnchor.constraint(equalTo: mapView.centerXAnchor), bikeButton.heightAnchor.constraint(equalToConstant: 50), bikeButton.widthAnchor.constraint(equalToConstant: 50)])
     }
     
     //MARK: -car button constraints

--- a/quavi/quavi/Controllers/MapView/MapViewController+SliderView+Constraints.swift
+++ b/quavi/quavi/Controllers/MapView/MapViewController+SliderView+Constraints.swift
@@ -24,20 +24,15 @@ extension MapViewController {
     }
     
     func createSliderViewConstraints() {
-        halfScreenSliderViewConstraints = sliderView.topAnchor.constraint(equalTo: view.bottomAnchor, constant:  -sliderViewHeight + 450)
-        halfScreenSliderViewConstraints?.isActive = true
-
-        closedSliderViewConstraints = sliderView.topAnchor.constraint(equalTo: view.bottomAnchor, constant: -120)
-        closedSliderViewConstraints?.isActive = false
-
-        fullScreenSliderViewConstraints = sliderView.topAnchor.constraint(equalTo: view.topAnchor, constant: 70)
-        fullScreenSliderViewConstraints?.isActive = false
-        
+        mapViewTopConstraint = mapView.topAnchor.constraint(equalTo: view.topAnchor, constant: -20)
         mapViewBottomConstraintHalf = mapView.bottomAnchor.constraint(equalTo: sliderView.topAnchor,constant: 75)
-        mapViewBottomConstraintHalf?.isActive = true
+        halfScreenSliderViewConstraints = sliderView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant:  -sliderViewHeight + 450)
+        NSLayoutConstraint.activate([mapViewTopConstraint!, mapViewBottomConstraintHalf!,halfScreenSliderViewConstraints!])
         
         mapViewBottomConstraintClosed = mapView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
-        mapViewBottomConstraintClosed?.isActive = false
+        closedSliderViewConstraints = sliderView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -120)
+        fullScreenSliderViewConstraints = sliderView.topAnchor.constraint(equalTo: view.topAnchor, constant: 70)
+        NSLayoutConstraint.deactivate([mapViewBottomConstraintClosed!,closedSliderViewConstraints!, fullScreenSliderViewConstraints! ])
     }
     
     func setFullOpenSliderViewConstraints() {

--- a/quavi/quavi/Controllers/MapView/MapViewController.swift
+++ b/quavi/quavi/Controllers/MapView/MapViewController.swift
@@ -72,6 +72,7 @@ class MapViewController: UIViewController {
     var closedSliderViewConstraints: NSLayoutConstraint?
     var fullScreenSliderViewConstraints: NSLayoutConstraint?
     
+    var mapViewTopConstraint: NSLayoutConstraint?
     var mapViewBottomConstraintHalf: NSLayoutConstraint?
     var mapViewBottomConstraintClosed: NSLayoutConstraint?
     

--- a/quavi/quavi/Supporting Files/SceneDelegate.swift
+++ b/quavi/quavi/Supporting Files/SceneDelegate.swift
@@ -21,8 +21,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         window = UIWindow(frame: UIScreen.main.bounds)
         window?.windowScene = windowScene
-//        window?.rootViewController = QuaviTabBarController()
-        window?.rootViewController = CategorySelectionViewController()
+        window?.rootViewController = QuaviTabBarController()
+        //window?.rootViewController = CategorySelectionViewController()
         window?.makeKeyAndVisible()
     }
 


### PR DESCRIPTION
fixed SliderView constraint for closed state to show categories and the transpo buttons to be within the safeArea and some refactoring of the constraints.