### PR TITLE
moves increment of nextStopIndex property from generateRouteForCurren…

### DIFF
--- a/quavi/quavi/Controllers/MapView/MapViewController+MapBox.swift
+++ b/quavi/quavi/Controllers/MapView/MapViewController+MapBox.swift
@@ -38,7 +38,6 @@ extension MapViewController: MGLMapViewDelegate {
                     print(error)
                 case .success(let route):
                     self.currentLegRoute = route
-                    self.nextStopIndex += 1
                 }
             }
         }

--- a/quavi/quavi/Controllers/MapView/MapViewController+Navigation.swift
+++ b/quavi/quavi/Controllers/MapView/MapViewController+Navigation.swift
@@ -22,7 +22,9 @@ extension MapViewController {
         let navigationVC = NavigationViewController(for: currentLegRoute, options: navigationOptions)
         navigationVC.delegate = self
         navigationVC.modalPresentationStyle = .fullScreen
-
+        
+        // Use this property to indicate when to change continue button to finish tour in POIInfoVC
+        nextStopIndex += 1
         present(navigationVC, animated: true)
     }
 


### PR DESCRIPTION
Fixes bug where app crashes when generating new tour more than number of stops for tour. Fixed by: 
- moved increment of nextStopIndex property from generateRouteForCurrentLeg in MapView+MapBox to startNavigationButtonPressed in MapView+Navigation

@aglegaspi 
