### PR TITLE
Dismiss multiple vcs

### DIFF
--- a/quavi/quavi/Controllers/MapView/MapViewController+Navigation+Delegate.swift
+++ b/quavi/quavi/Controllers/MapView/MapViewController+Navigation+Delegate.swift
@@ -20,7 +20,9 @@ extension MapViewController: NavigationViewControllerDelegate{
         
         let popupViewController = POIPopUpViewController()
         //popupViewController.delegate = self
-        navigationViewController.present(popupViewController, animated: true, completion: nil)
+        
+        navigationViewController.navigationService.stop()
+        navigationViewController.present(popupViewController, animated: true)
         return false
     }
 }

--- a/quavi/quavi/Controllers/POI Info/POIInfoViewController.swift
+++ b/quavi/quavi/Controllers/POI Info/POIInfoViewController.swift
@@ -104,7 +104,9 @@ class POIInfoViewController: UIViewController {
     //MARK:--@objc func
     @objc func continueButtonPressed(_ sender: UIButton) {
         #warning("push to mapVC")
-       }
+//        self.dismiss(animated: true)
+        self.presentingViewController?.presentingViewController?.presentingViewController?.dismiss(animated: true, completion: nil)
+    }
     
     @objc func handlePresentingMLView(_sender: UIButton){
         self.showAlert(title: "Coming Soon...", message: "The team is currently working on the feature to allow for an easter egg scavenger hunt ")

--- a/quavi/quavi/Controllers/POI PopUp/POIPopUpViewController.swift
+++ b/quavi/quavi/Controllers/POI PopUp/POIPopUpViewController.swift
@@ -71,8 +71,8 @@ class POIPopUpViewController: UIViewController {
     
     
     @objc func cancelTourButtonPressed() {
-        self.dismiss(animated: true)
-        #warning("pop back to mapviewVC")
+       // Pop PopUp and Navigation ViewControllers
+        self.presentingViewController?.presentingViewController?.dismiss(animated: true, completion: nil)
     }
     
     @objc func continueTourButtonPressed(_ sender:UIButton) {


### PR DESCRIPTION
- Stops navigation services when PopUpVC is triggered

On PopUpVC:
- Pops PopUpVC and NavigationVC when 'cancel tour' button is pressed

On POIInfoVC:
- Pops POIInfoVC, PopUPVC, and NavigationVC when 'continue tour' button is pressed

[Asana Card](https://app.asana.com/0/1162491857958380/1164029749408449)

@aglegaspi 
