### PR TITLE
fixes logic to navigate back to tabBarVC

### DIFF
--- a/quavi/quavi/Controllers/POI PopUp/POIPopUpFinalViewController.swift
+++ b/quavi/quavi/Controllers/POI PopUp/POIPopUpFinalViewController.swift
@@ -91,7 +91,7 @@ class POIPopUpFinalViewController: UIViewController {
     }
     
     @objc func cancelTourButtonPressed() {
-        self.presentingViewController?.presentingViewController?.presentingViewController?.presentingViewController?.dismiss(animated: true, completion: nil)
+        self.presentingViewController?.presentingViewController?.presentingViewController?.dismiss(animated: true, completion: nil)
     }
     
 }


### PR DESCRIPTION
fixes logic to navigate back to tabBarVC when cancel button is clicked in the POIInfoVC