### PR TITLE
Dev fb mode of transport fix

### DIFF
--- a/quavi/quavi/Controllers/POI Info/POIInfoViewController+objc.swift
+++ b/quavi/quavi/Controllers/POI Info/POIInfoViewController+objc.swift
@@ -83,7 +83,7 @@ extension POIInfoViewController {
     
     private func changePresentModesOfTransportBackgroundColor() {
         presentModesOfTransport.backgroundColor = presentModesOfTransport.backgroundColor == .white ? UIDesign.quaviLightGrey : .white
-        presentModesOfTransport.tintColor = presentModesOfTransport.tintColor == .white ? UIDesign.quaviLightGrey : .white
+        presentModesOfTransport.tintColor = presentModesOfTransport.tintColor == .black ? UIDesign.quaviLightGrey : .black
     }
     
     private func presentButtons() {

--- a/quavi/quavi/Controllers/POI Info/POIInfoViewController+objc.swift
+++ b/quavi/quavi/Controllers/POI Info/POIInfoViewController+objc.swift
@@ -30,15 +30,23 @@ extension POIInfoViewController {
      }
      
      @objc func continueButtonPressed(_ sender: UIButton) {
-        guard let currentLegRoute = currentLegRoute else { return }
-        let navigationService = MapboxNavigationService(route: currentLegRoute, simulating: .always )
-        let navigationOptions = NavigationOptions(navigationService: navigationService)
-        let navigationVC = NavigationViewController(for: currentLegRoute, options: navigationOptions)
-        navigationVC.delegate = self
-        navigationVC.modalPresentationStyle = .fullScreen
-        present(navigationVC, animated: true)
+        
+        switch showButtons{
+        case .hide:
+           presentNavigationVC()
+            
+        case .show:
+           activateTopConstraints()
+            presentButtons()
+            showButtons = .hide
+           presentModesOfTransport.setImage(UIImage(systemName: "location.fill")!, for: .normal)
+           
+            if showButtons == .hide{
+            presentNavigationVC()
+        }
      }
-     
+    }
+    
      @objc func handleFinishButtonPressed(_ sender: UIButton) {
          let popupFinalVC = POIPopUpFinalViewController()
          popupFinalVC.modalPresentationStyle = .fullScreen

--- a/quavi/quavi/Controllers/POI Info/POIInfoViewController+objc.swift
+++ b/quavi/quavi/Controllers/POI Info/POIInfoViewController+objc.swift
@@ -58,6 +58,16 @@ extension POIInfoViewController {
            bikeButton.alpha = bikeButton.alpha == 1 ? 0: 1
        }
     
+    private func presentNavigationVC(){
+        guard let currentLegRoute = currentLegRoute else { return }
+                   let navigationService = MapboxNavigationService(route: currentLegRoute, simulating: .always )
+                   let navigationOptions = NavigationOptions(navigationService: navigationService)
+                   let navigationVC = NavigationViewController(for: currentLegRoute, options: navigationOptions)
+                   navigationVC.delegate = self
+                   navigationVC.modalPresentationStyle = .fullScreen
+                   present(navigationVC, animated: true)
+    }
+    
     private func activateNewTopConstraints() {
            NSLayoutConstraint.deactivate([carButtonTopConstraint!, bikeButtonTopConstraint!, walkButtonTopConstraint!])
            NSLayoutConstraint.activate([newCarButtonTopConstraint!, newWalkButtonTopConstraint!, newBikeButtonTopConstraint!])


### PR DESCRIPTION
 Creates a presentNavigationVC func to present the navigation view controller when the next button is pressed
Adds a switch statement to dismiss the M.O.T buttons before presenting the navigationVC if the showButtons = .show or present the navigationVC if the showButtons = .hide
Fixes the presentModesOfTransport tintColor when presented and dismissed

[Asana](https://app.asana.com/0/1166692794043650/1168326367726475)
[Asana](https://app.asana.com/0/1166692794043650/1167878841579057)
